### PR TITLE
Only send dirty attributes when updating a record

### DIFF
--- a/lib/betty_resource/model/record.rb
+++ b/lib/betty_resource/model/record.rb
@@ -83,7 +83,7 @@ module BettyResource
 
         result = begin
           if new_record?
-            Api.post("/models/#{model.id}/records/new", to_update_params)
+            Api.post("/models/#{model.id}/records/new", to_params)
           else
             Api.put("/models/#{model.id}/records/#{id}", to_params)
           end
@@ -112,19 +112,15 @@ module BettyResource
     private
 
       def to_params
-        { body: { record: attributes_as_json }, headers: { 'Content-Type' => 'application/json' } }
+        { body: { record: dirty_attributes_as_json }, headers: { 'Content-Type' => 'application/json' } }
       end
 
-      def to_update_params
-        {body: {record: dirty_attributes_as_json}, headers: {'Content-Type' => 'application/json'}}
-      end
-
-      def dirty_attributes_as_json
-        changes.inject({}) do |hash, change|
-          hash[change.first] = change.last.last
+      def dirty_attributes_as_json(options = {})
+        changes.reduce({}) do |hash, (property_name, (was, new_value))|
+          hash.merge!({property_name => (new_value.respond_to?(:as_json) ? new_value.as_json(options) : new_value)})
           hash
         end
-       end
+      end
 
       # TODO: Test this update
       def attributes_as_json(options = {})


### PR DESCRIPTION
Instead of sending all attributes of the record it now only sends dirty attributes
